### PR TITLE
Fixed bug with ant not showing topbar and analytics

### DIFF
--- a/packages/fe-container/src/App.less
+++ b/packages/fe-container/src/App.less
@@ -22,8 +22,5 @@
 .ant-layout {
   min-height: 100%;
   height: 100%;
-}
-
-.ant-layout-content {
-  min-height: 100%;
+  background-color: var(--microlc-body-background);
 }


### PR DESCRIPTION
Bugfix for ant that was taking the entire viewport with some plugin hiding the top bar and the analytics footer bar 